### PR TITLE
Fix default suffixes in help message

### DIFF
--- a/src/OpinionatedCsharpTodos/Program.cs
+++ b/src/OpinionatedCsharpTodos/Program.cs
@@ -286,7 +286,7 @@ namespace OpinionatedCsharpTodos
                 new Option<string[]?>(
                     new[]{"--suffixes"},
                     "Suffix regular expressions that TODOs must conform to. " +
-                    $"[Default: {string.Join(" ", DefaultDisallowedPrefixes)}]"
+                    $"[Default: {string.Join(" ", DefaultSuffixes)}]"
                 ),
 
                 new Option<bool>(


### PR DESCRIPTION
There was a copy/paste error so the default value in the help message
mistakenly showed disallowed prefixes for the default suffixes.