### PR TITLE
Fix out-of-bounds in margin stripping

### DIFF
--- a/recipes/powershell/RenderTaskList.ps1
+++ b/recipes/powershell/RenderTaskList.ps1
@@ -21,13 +21,96 @@ param(
 
 <#
 .SYNOPSIS
-This script renders SVG badges using shields.io service.
+This script renders the tasks as a markdown.
 #>
 
 $nl = [Environment]::NewLine
 $todoRe = [Regex]::new(' \(([^)]+), ([0-9]{4}-[0-9]{2}-[0-9]{2})\): ')
-$suffixWhitespaceRe = [Regex]::new('^[ \t]*')
 
+function StripMarginFromSecondLineOn([string]$Text)
+{
+    $lines = $Text.Split(@("`r`n", "`r", "`n"), [StringSplitOptions]::None)
+    if ($lines.Count -lt 2)
+    {
+        return $Text
+    }
+
+    if($lines.Count -eq 2)
+    {
+        $lines[1] = $lines[1].TrimStart()
+        return ($lines -Join $nl)
+    }
+
+    $minLength = $null
+    for($i = 1; $i -lt $lines.Length; $i++)
+    {
+        # Empty lines are ignored since IDEs sometimes strip them away and
+        # do not indent them with whitespace.
+        if ($lines[$i].Length -eq 0)
+        {
+            continue
+        }
+
+        if (($null -eq $minLength) -or ($lines[$i].Length -lt $minLength))
+        {
+            $minLength = $lines[$i].Length
+        }
+    }
+
+    if($null -eq $minLength)
+    {
+        # All lines from the second on were empty.
+        return $Text
+    }
+
+    $commonMarginLength = 0
+    $stop = $false
+    for($cursor = 0; !$stop -and ($cursor -lt $minLength); $cursor++)
+    {
+        $charAtCursor = $null
+
+        for($i = 1; !$stop -and ($i -lt $lines.Length); $i++)
+        {
+            # Skip empty lines, see the comment above
+            if ($lines[$i].Length -eq 0)
+            {
+                continue
+            }
+
+            if ($null -eq $charAtCursor)
+            {
+                $charAtCursor = $lines[$i][$cursor]
+                if (($charAtCursor -ne " ") -and ($charAtCursor -ne "`t"))
+                {
+                    $commonMarginLength = $cursor
+                    $stop = $true
+                }
+            }
+            else
+            {
+                if ($lines[$i][$cursor] -ne $charAtCursor)
+                {
+                    $commonMarginLength = $cursor
+                    $stop = $true
+                }
+            }
+        }
+    }
+
+    for($i = 1; $i -lt $lines.Length; $i++)
+    {
+        # Skip empty lines, see the comment above
+        if ($lines[$i].Length -eq 0)
+        {
+            continue
+        }
+        $lines[$i] = $lines[$i].Substring($commonMarginLength)
+    }
+
+    $result = $lines -Join $nl
+
+    return $result
+}
 
 function ParseSuffix($Suffix)
 {
@@ -39,47 +122,9 @@ function ParseSuffix($Suffix)
 
     $author = $mtch.Groups[1].Value
     $date = $mtch.Groups[2].Value
+
     $remainder = $Suffix.Substring($mtch.Value.Length)
-
-    $lines = $remainder.Split(@("`r`n", "`r", "`n"), [StringSplitOptions]::None)
-    if($lines.Count -lt 2)
-    {
-        $text = $remainder
-    }
-    elseif($lines.Count -eq 2)
-    {
-        $lines[1] = $lines[1].Trim()
-        $text = $lines -Join $nl
-    }
-    else
-    {
-        $wsMtch = $suffixWhitespaceRe.Match($lines[1])
-        if($wsMtch.Success)
-        {
-            $minMargin = $wsMtch.Value.Length
-
-            for($i=2; $i -lt $lines.Length; $i++)
-            {
-                $line = $lines[$i]
-
-                for($j = 0; ($j -lt $line.Length) -and ($j -lt $minMargin); $j++)
-                {
-                    $char = $line[$j]
-                    if($char -ne $wsMtch.Value[$j])
-                    {
-                        $minMargin = $j
-                    }
-                }
-            }
-        }
-
-        for($i = 1; $i -lt $lines.Length; $i++)
-        {
-            $lines[$i] = $lines[$i].Substring($minMargin)
-        }
-        $text = $lines -Join $nl
-    }
-
+    $text = StripMarginFromSecondLineOn -Text $remainder
 
     [hashtable]$result = @{ }
     $result.Author = $author

--- a/recipes/powershell/StripMarginFromSecondLineOn.Test.ps1
+++ b/recipes/powershell/StripMarginFromSecondLineOn.Test.ps1
@@ -1,0 +1,195 @@
+<#
+.SYNOPSIS
+This script tests StripMargin function in-lined from RenderTaskList.ps1.
+
+.DESCRIPTION
+This is a simple development environment for StripMargin used in
+RenderTaskList.ps1. We did not want to set up the whole test framework such
+as Pester since there is too little to test for.
+
+In the future, we might consider introducing Pester if the number of functions
+grow.
+#>
+
+$nl = [Environment]::NewLine
+
+function StripMarginFromSecondLineOn([string]$Text)
+{
+    $lines = $Text.Split(@("`r`n", "`r", "`n"), [StringSplitOptions]::None)
+    if ($lines.Count -lt 2)
+    {
+        return $Text
+    }
+
+    if($lines.Count -eq 2)
+    {
+        $lines[1] = $lines[1].TrimStart()
+        return ($lines -Join $nl)
+    }
+
+    $minLength = $null
+    for($i = 1; $i -lt $lines.Length; $i++)
+    {
+        # Empty lines are ignored since IDEs sometimes strip them away and
+        # do not indent them with whitespace.
+        if ($lines[$i].Length -eq 0)
+        {
+            continue
+        }
+
+        if (($null -eq $minLength) -or ($lines[$i].Length -lt $minLength))
+        {
+            $minLength = $lines[$i].Length
+        }
+    }
+
+    if($null -eq $minLength)
+    {
+        # All lines from the second on were empty.
+        return $Text
+    }
+
+    $commonMarginLength = 0
+    $stop = $false
+    for($cursor = 0; !$stop -and ($cursor -lt $minLength); $cursor++)
+    {
+        $charAtCursor = $null
+
+        for($i = 1; !$stop -and ($i -lt $lines.Length); $i++)
+        {
+            # Skip empty lines, see the comment above
+            if ($lines[$i].Length -eq 0)
+            {
+                continue
+            }
+
+            if ($null -eq $charAtCursor)
+            {
+                $charAtCursor = $lines[$i][$cursor]
+                if (($charAtCursor -ne " ") -and ($charAtCursor -ne "`t"))
+                {
+                    $commonMarginLength = $cursor
+                    $stop = $true
+                }
+            }
+            else
+            {
+                if ($lines[$i][$cursor] -ne $charAtCursor)
+                {
+                    $commonMarginLength = $cursor
+                    $stop = $true
+                }
+            }
+        }
+    }
+
+    for($i = 1; $i -lt $lines.Length; $i++)
+    {
+        # Skip empty lines, see the comment above
+        if ($lines[$i].Length -eq 0)
+        {
+            continue
+        }
+        $lines[$i] = $lines[$i].Substring($commonMarginLength)
+    }
+
+    $result = $lines -Join $nl
+
+    return $result
+}
+
+function Test
+{
+    $cases = @(
+    [System.Tuple]::Create(
+            "",
+            "",
+            "Empty"),
+
+    [System.Tuple]::Create(
+            "This is a one-liner.",
+            "This is a one-liner.",
+            "One-liner"),
+
+    [System.Tuple]::Create(
+            "AAA${nl}BBB",
+            "AAA${nl}BBB",
+            "Two-liner without margin"),
+
+    [System.Tuple]::Create(
+            "AAA${nl}   BBB",
+            "AAA${nl}BBB",
+            "Two-liner with margin"),
+
+    [System.Tuple]::Create(
+            "AAA${nl}",
+            "AAA${nl}",
+            "Two-liner with empty second line"),
+
+    [System.Tuple]::Create(
+            "AAA${nl}BBB${nl}CCC",
+            "AAA${nl}BBB${nl}CCC",
+            "Three-liner without margin"),
+
+    [System.Tuple]::Create(
+            "AAA${nl}  BBB${nl}  CCC",
+            "AAA${nl}BBB${nl}CCC",
+            "Three-liner with identical margins"),
+
+    [System.Tuple]::Create(
+            "AAA${nl}    BBB${nl}  CCC",
+            "AAA${nl}  BBB${nl}CCC",
+            "Three-liner with decreasing margins"),
+
+    [System.Tuple]::Create(
+            "AAA${nl}  BBB${nl}    CCC",
+            "AAA${nl}BBB${nl}  CCC",
+            "Three-liner with increasing margins"),
+
+    [System.Tuple]::Create(
+            "AAA${nl}${nl}CCC",
+            "AAA${nl}${nl}CCC",
+            "Three-liner with empty middle line and no margin"),
+
+    [System.Tuple]::Create(
+            "AAA${nl}${nl}  CCC",
+            "AAA${nl}${nl}CCC",
+            "Three-liner with empty middle line and margin in the last line"),
+
+    [System.Tuple]::Create(
+            "AAA${nl}  BBB${nl}",
+            "AAA${nl}BBB${nl}",
+            "Three-liner with empty last line and margin in the middle"),
+
+    [System.Tuple]::Create(
+            "AAA${nl}  BBB${nl}    CCC${nl}  DDD",
+            "AAA${nl}BBB${nl}  CCC${nl}DDD",
+            "Four-liner with increasing and decreasing margins"),
+
+    [System.Tuple]::Create(
+            "AAA${nl}${nl}    CCC${nl}  DDD",
+            "AAA${nl}${nl}  CCC${nl}DDD",
+            "Four-liner with variable margins and empty second line")
+    )
+
+    foreach ($cs in $cases)
+    {
+        $text = $cs.Item1
+        $expected = $cs.Item2
+        $label = $cs.Item3
+
+        $got = StripMarginFromSecondLineOn($text)
+        if ($expected -ne $got)
+        {
+            throw ("${label}: " +
+                    "expected $( $expected|ConvertTo-Json ), " +
+                    "got: $( $got|ConvertTo-Json )")
+        }
+        else
+        {
+            Write-Host "${label}: OK"
+        }
+    }
+}
+
+Test


### PR DESCRIPTION
This patch fixes an out-of-bounds error in the powershell recipe for
rendering the task list.

The algorithm for stripping margins in the recipe was unnecessarily
complicated, so it was simplified.

To avoid some obvious future bugs, the unit tests for this function were
added.